### PR TITLE
Set django settings module on pytest.ini

### DIFF
--- a/src/pytest.ini
+++ b/src/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = videoclub.settings


### PR DESCRIPTION
I've tried to run pytest and I got an error saying that it was necessary to specify DJANGO_SETTINGS_MODULE. So I've created a pytest.ini file to specify the settings module in there. Now it's possible just go inside src and run `pytest`. I'm not sure if there's a better way to do that though.